### PR TITLE
fix add-officer to filter units based on department id ddl

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -756,6 +756,18 @@ def get_dept_ranks(department_id=None, is_sworn_officer=None):
 
     return jsonify(rank_list)
 
+@main.route('/units')
+def get_dept_units(department_id=None):
+    if not department_id:
+        department_id = request.args.get('department_id')
+
+    if department_id:
+        units = Unit.query.filter_by(department_id=department_id)
+        unit_list = list(set([(unit.id, unit.descrip) for unit in units]))
+    else:
+        units = Unit.query.all()  # Not filtering by is_sworn_officer
+        unit_list = list(set([(unit.id, unit.descrip) for unit in units]))  # Prevent duplicate units
+    return jsonify(unit_list)
 
 @main.route('/officer/new', methods=['GET', 'POST'])
 @login_required

--- a/OpenOversight/app/static/js/add_officer.js
+++ b/OpenOversight/app/static/js/add_officer.js
@@ -13,6 +13,18 @@ function set_jobs() {
       );
     }
   });
+  var units_url = $('#add-officer-form').data('units-url');
+  var units = $.ajax({
+    url: units_url,
+    data: {department_id: dept_id}
+  }).done(function(units) {
+    $('#unit').replaceWith('<select class="form-control" id="unit" name="unit">');
+    for (i = 0; i < units.length; i++) {
+      $('select#unit').append(
+        $('<option></option>').attr("value", units[i][0]).text(units[i][1])
+      );
+    }
+  });
 }
 
 $(document).ready(function() {

--- a/OpenOversight/app/templates/add_officer.html
+++ b/OpenOversight/app/templates/add_officer.html
@@ -9,7 +9,7 @@
     <h1>Add Officer</h1>
 </div>
 <div class="col-md-6">
-    <form class="form" method="post" role="form" id="add-officer-form" data-jobs-url="{{ url_for('main.get_dept_ranks') }}">
+    <form class="form" method="post" role="form" id="add-officer-form" data-jobs-url="{{ url_for('main.get_dept_ranks') }}" data-units-url="{{ url_for('main.get_dept_units') }}">
         {{ form.hidden_tag() }}
         {{ wtf.form_errors(form, hiddens="only") }}
         {{ wtf.form_field(form.department) }}


### PR DESCRIPTION
contributes to #58 , we can;t fix the rest of the pages if the main function doesn't filter units based on department id.