### PR TITLE
added links to donate page with matching color

### DIFF
--- a/OpenOversight/app/templates/donate.html
+++ b/OpenOversight/app/templates/donate.html
@@ -25,7 +25,7 @@
             </div>
         </div>
         <div class="col-sm-12 col-md-6" style="text-align:center">
-            <h1>You can also make a donation from these links</h1>
+            <h1>Other Donation Links</h1>
             <p>
                 <ul style="list-style-type:none;">
                     <li><a class="btn btn-lg btn-secondary" style="background-color: #128AED; margin-bottom: 10px; border-color: #128AED;" href="https://www.paypal.com/donate/?hosted_button_id=AMDBNH5G5CWEN" target="_new">Paypal</a></li>


### PR DESCRIPTION
posted live

closes #80 

we can't add the other options like cashapp/ach without hosting the form our selves which opens us up to pci complaince issue. ApplyPay wont' work on an embedded form so I added a direct link to the page for people who want to use applypay.