### PR TITLE
Revamp download page

### DIFF
--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1173,7 +1173,7 @@ def list_officer(
         unique_internal_identifier=form_data["unique_internal_identifier"],
         unit=form_data["unit"],
         current_job=form_data["current_job"],
-        require_photo='Y' if form_data["require_photo"] else '',
+        require_photo='Y' if form_data["require_photo"] else None,
     )
     prev_url = url_for(
         "main.list_officer",
@@ -1190,7 +1190,7 @@ def list_officer(
         unique_internal_identifier=form_data["unique_internal_identifier"],
         unit=form_data["unit"],
         current_job=form_data["current_job"],
-        require_photo='Y' if form_data["require_photo"] else '',
+        require_photo='Y' if form_data["require_photo"] else None,
     )
 
     return render_template(

--- a/OpenOversight/app/main/views.py
+++ b/OpenOversight/app/main/views.py
@@ -1980,7 +1980,7 @@ def download_dept_descriptions_csv(department_id: int):
 @sitemap_include
 @main.route("/download/all", methods=[HTTPMethod.GET])
 def all_data():
-    departments = Department.query.filter(Department.officers.any())
+    departments = Department.query.filter(Department.officers.any()).order_by(Department.name)
     return render_template("departments_all.html", departments=departments)
 
 

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -133,17 +133,25 @@ a > .tutorial{
    min-height: 700px;
    margin-top: 50px;
  }
- .carousel-inner > .item > img {
-   position: absolute;
+ .carousel-inner > .item img {
+   /*
    top: 0;
    left: 0;
    width: 100%;
+   KF - allow overflow but center
+   */
+   margin-left: 50%;
+   transform: translateX(-50%);
+   max-width: unset !important;
  }
 
  /* Limit image width to avoid overflow the cropper container */
+ /* KF - turn this off because it squishes large pics
+  * prefer stretch-to-height, allow overflow but centered
  img {
    max-width: 100%;
  }
+ */
 
  meter {
      margin: 0 auto 1em;
@@ -703,4 +711,3 @@ table.display th, table.display td {
 #add-assignment-form {
     overflow: hidden;
 }
-

--- a/OpenOversight/app/static/css/openoversight.css
+++ b/OpenOversight/app/static/css/openoversight.css
@@ -703,3 +703,4 @@ table.display th, table.display td {
 #add-assignment-form {
     overflow: hidden;
 }
+

--- a/OpenOversight/app/static/scss/index.scss
+++ b/OpenOversight/app/static/scss/index.scss
@@ -9,6 +9,8 @@ $navbar-default-toggle-border-color: #333333;
 $navbar-default-toggle-icon-bar-bg: #333333;
 $navbar-default-toggle-hover-bg: #D3D3D3;
 
+$grid-float-breakpoint: 1090px;
+
 @import "bootstrap";
 
 .navbar-link {

--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -62,8 +62,8 @@
 
   <body role="document">
 
-    <nav class="navbar navbar-default navbar-fixed-top">
-      <div class="container">
+    <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
+      <!--div class="container"-->
           <div class="navbar-header navbar-default">
             <button type="button" class="navbar-default navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
               <span class="sr-only">Toggle navigation</span>
@@ -123,7 +123,7 @@
               {% endif %}
             </ul>
         </div>
-      </div>
+      <!--/div-->
     </nav>
 
     {% with messages = get_flashed_messages() %}
@@ -154,8 +154,6 @@
             Virginia's only statewide police transparency database. Codebase and concept thanks to the original OpenOversight
             instance by <a href="https://lucyparsonslabs.com/" target="_blank" class="btn-unstyled">Lucy Parsons Labs</a>
             in Chicago, IL. We are volunteer-run and donation-funded.<br>
-            <!--<a href="https://lucyparsonslabs.com/securedrop/" target="_blank" class="btn-unstyled">SecureDrop</a><br>
-            --><a href="{{ url_for('main.all_data') }}" target="_blank" class="btn-unstyled">Download department data</a>
           </p>
         </div>
 
@@ -165,8 +163,10 @@
               <a href="mailto:alice@openoversightva.org" class="btn-unstyled">Admin</a> | 
               <a href="mailto:legal@openoversightva.org" class="btn-unstyled">Legal</a> | 
               <a href="mailto:press@openoversightva.org" class="btn-unstyled">Press</a>
-            <br>
+          </p><p>
             <a href="/privacy" class="btn">Privacy Policy</a>
+            <br>
+            <a href="{{ url_for('main.all_data') }}" target="_blank" class="btn-unstyled">Download data</a>
           </p>
         </div>
         <div class="col-sm-4">
@@ -190,5 +190,6 @@
       <script src="{{ url_for('static', filename=item) }}"></script>
       {% endfor %}
     {% endblock js_footer %}
+
   </body>
 </html>

--- a/OpenOversight/app/templates/departments_all.html
+++ b/OpenOversight/app/templates/departments_all.html
@@ -1,26 +1,55 @@
 {% extends "base.html" %}
 {% import "bootstrap/wtf.html" as wtf %}
+{% block title %}
+  Download department data - OpenOversight
+{% endblock title %}
 {% block content %}
 
-    <div class="container theme-showcase" role="main">
-
-        <div class="text-center frontpage-leads">
-            {% for dept in departments %}
-                <p>
-                <h2>{{ dept.name }}</h2>
+    <div class="container" role="main">
+        <div class="row">
+        <h1>Download Data</h1>
+        <div class="text-center frontpage-leads col-md-8">
+            <h2>Download by Department</h2>
+            <select class="form-control" id="department" name="department">
+                <option value="" selected> - Select a department - </option>
+                {% for dept in departments %}
+                    <option value="{{ dept.id }}">{{ dept.name }}</option>
+                {% endfor %}
+            </select>
+            <div id="dept_links" style="display:none">
+                <h2>dept_name</h2>
                 <ul class="list-group">
-                    <a href={{ url_for('main.download_dept_officers_csv',department_id=dept.id) }}><li class="list-group-item">officers.csv</li></a>
-                    <a href={{ url_for('main.download_dept_assignments_csv',department_id=dept.id) }}><li class="list-group-item">assignments.csv</li></a>
-                    <a href={{ url_for('main.download_dept_salaries_csv',department_id=dept.id) }}><li class="list-group-item">salaries.csv</li></a>
-                    <a href={{ url_for('main.download_dept_links_csv',department_id=dept.id) }}><li class="list-group-item">links.csv</li></a>
-                    <a href={{ url_for('main.download_dept_descriptions_csv',department_id=dept.id) }}><li class="list-group-item">descriptions.csv</li></a>
-                    {% if dept.incidents %}
-                        <a href={{ url_for('main.download_incidents_csv',department_id=dept.id) }}><li class="list-group-item">incidents.csv</li></a>
-                    {% endif %}
+                    <a href="/download/departments/ID/officers"><li class="list-group-item">officers.csv</li></a>
+                    <a href="/download/departments/ID/incidents"><li class="list-group-item">incidents.csv</li></a>
+                    <a href="/download/departments/ID/assignments"><li class="list-group-item">assignments.csv</li></a>
+                    <a href="/download/departments/ID/salaries"><li class="list-group-item">salaries.csv</li></a>
                 </ul>
-                </p>
-            {% endfor %}
+            </div>
         </div>
     </div>
+
+<script>
+function update_links() {
+  var dept_id = $('#department').val();
+  var dept_name = $('#department option:selected').text();
+
+  if (dept_id) {
+      $('#dept_links').replaceWith(`<div id="dept_links"><h2>${dept_name}</h2>
+                    <ul class="list-group">
+                        <a href="/download/departments/${dept_id}/officers"><li class="list-group-item">officers.csv</li></a>
+                        <a href="/download/departments/${dept_id}/incidents"><li class="list-group-item">incidents.csv</li></a>
+                        <a href="/download/departments/${dept_id}/assignments"><li class="list-group-item">assignments.csv</li></a>
+                        <a href="/download/departments/${dept_id}/salaries"><li class="list-group-item">salaries.csv</li></a>
+                    </ul>
+                </div>`);
+  } else {
+    $('#dept_links').replaceWith('<div id="dept_links"></div>');
+  }
+}
+
+$(document).ready(function() {
+  $('#department').change(update_links);
+});
+</script>
 
 {% endblock %}

--- a/OpenOversight/app/templates/list_officer.html
+++ b/OpenOversight/app/templates/list_officer.html
@@ -13,6 +13,12 @@
 {% endblock head %}
 {% block content %}
   <div class="container" role="main">
+    <div class="pull-right" id="csv-download" style="margin: 34px 0 10px 0;">
+      <a href="/download/department/{{ department.id }}/officers" title="Download Roster as CSV">
+        <span class="visible-md-inline visible-lg-inline">Download</span>
+        <span class="glyphicon glyphicon-download-alt" style="font-size: 18px"></span>
+      </a>
+    </div>
     <h1>{{ department.display_name }} Officers</h1>
     <div class="row">
       <div class="filter-sidebar col-sm-3">

--- a/OpenOversight/app/templates/news/index.html
+++ b/OpenOversight/app/templates/news/index.html
@@ -16,7 +16,7 @@
           <h1>{{ post.title }}</h1>
           <div class="about">by {{ post.creator.username }} on {{ post.created_at.strftime('%Y-%m-%d') }}</div>
         </div>
-        {% if current_user.id == post.user_id %}
+        {% if (current_user.id == post.user_id) or current_user.is_administrator %}
           <a class="action" href="{{ url_for('main.edit_post', post_id=post.id) }}">Edit</a>
         {% endif %}
       </header>

--- a/OpenOversight/app/templates/partials/officer_faces.html
+++ b/OpenOversight/app/templates/partials/officer_faces.html
@@ -5,16 +5,16 @@
   <div class="carousel-inner">
     {% for face, path in face_paths %}
       <div class="item{{ ' active' if loop.index == 1 else '' }}">
-        <div class="row text-center">
-          <div class="col-12">
+        <!--div class="row text-center"-->
+          <!--div class="col-12"-->
             {# Don't try to link if only image is the placeholder #}
             {% if face %}<a href="{{ url_for('main.display_tag', tag_id=face.id) }}">{% endif %}
               <img class="officer-face officer-profile"
                    src="{{ path }}"
                    alt="Submission">
               {% if face %}</a>{% endif %}
-          </div>
-        </div>
+          <!--/div-->
+        <!--/div-->
       </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
1. revamped /download/all page to pick a department instead of just listing them all 
2. add roster dl link+icon to dept officer list page (in upper right)
3. fix responsive header collapse (try resizing window, the top bar shouldn't look awful)
4. fix glitch on dept officer list page list_officer(), where "require_photo=False" in the URL string would cause zero records to display
